### PR TITLE
Update tests/phpunit/bootstrap.php

### DIFF
--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -11,8 +11,6 @@ if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
 }
 
-require_once TESTS_PLUGIN_DIR . '/vendor/autoload.php';
-
 if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 } else {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -11,6 +11,10 @@ if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
 }
 
+if ( file_exists( TESTS_PLUGIN_DIR . '/vendor/autoload.php' ) ) {
+	require_once TESTS_PLUGIN_DIR . '/vendor/autoload.php';
+}
+
 if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 } else {


### PR DESCRIPTION
The `[plugin-root]/vendor/autoload.php` directory and file don't exist by default and don't seem needed to run the tests. Remove the `include()`.

Alternatively it can do `file_exists()` before that.