### PR TITLE
Remove support for iframes

### DIFF
--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -46,7 +46,7 @@ class Tests_Media extends WP_UnitTestCase {
 			<p>Image, with pre-existing "loading" attribute.</p>
 			%5$s
 
-			<p>Iframe, standard. Should not be modified by default.</p>
+			<p>Iframe, standard. Should not be modified.</p>
 			%4$s';
 
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
@@ -59,21 +59,16 @@ class Tests_Media extends WP_UnitTestCase {
 	 * @ticket 44427
 	 */
 	function test_wp_lazy_load_content_media_opted_in() {
-		$img    = get_image_tag( self::$large_id, '', '', '', 'medium' );
-		$iframe = '<iframe src="https://www.example.com"></iframe>';
+		$img = get_image_tag( self::$large_id, '', '', '', 'medium' );
 
-		$lazy_img    = str_replace( '<img ', '<img loading="lazy" ', $img );
-		$lazy_iframe = str_replace( '<iframe ', '<iframe loading="lazy" ', $iframe );
+		$lazy_img = str_replace( '<img ', '<img loading="lazy" ', $img );
 
 		$content = '
 			<p>Image, standard.</p>
-			%1$s
+			%1$s';
 
-			<p>Iframe, standard.</p>
-			%2$s';
-
-		$content_unfiltered = sprintf( $content, $img, $iframe );
-		$content_filtered   = sprintf( $content, $lazy_img, $lazy_iframe );
+		$content_unfiltered = sprintf( $content, $img );
+		$content_filtered   = sprintf( $content, $lazy_img );
 
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -119,31 +119,31 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
 	return (bool) apply_filters( 'wp_lazy_loading_enabled', $default, $tag_name, $context );
 }
 
-
-// TODO: update docs.
 /**
- * Add `loading="lazy"` to `img` HTML tags if enabled.
+ * Add `loading="lazy"` to `img` HTML tags.
  *
  * Currently the "loading" attribute is only supported for `img`, and is enabled by default.
  *
  * @since (TBD)
  *
- * @param string $content The raw post content to be filtered.
+ * @param string $content The HTML content to be filtered.
  * @param string $context Optional. Additional context to pass to the filters. Defaults to `current_filter()` when not set.
  * @return string Converted content with 'loading' attributes added to images.
  */
 function wp_add_lazy_load_attributes( $content, $context = null ) {
+	if ( null === $context ) {
+		$context = current_filter();
+	}
+
 	if ( ! wp_lazy_loading_enabled( 'img', $context ) ) {
 		return $content;
 	}
 
 	return preg_replace_callback(
-		'/<img(\s)[^>]+>/',
+		'/<img\s[^>]+>/',
 		function( array $matches ) {
 			if ( ! preg_match( '/\sloading\s*=/', $matches[0] ) ) {
-				$space = $matches[1];
-
-				return str_replace( '<img' . $space, '<img' . $space . 'loading="lazy" ', $matches[0] );
+				return str_replace( '<img', '<img loading="lazy"', $matches[0] );
 			}
 
 			return $matches[0];

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -122,10 +122,9 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
 
 // TODO: update docs.
 /**
- * Add `loading="lazy"` to `img` and/or `iframe` HTML tags.
+ * Add `loading="lazy"` to `img` HTML tags if enabled.
  *
  * Currently the "loading" attribute is only supported for `img`, and is enabled by default.
- * Support for `iframe` is for testing purposes only.
  *
  * @since (TBD)
  *
@@ -134,33 +133,17 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
  * @return string Converted content with 'loading' attributes added to images.
  */
 function wp_add_lazy_load_attributes( $content, $context = null ) {
-	$tags = array();
-
-	if ( null === $context ) {
-		$context = current_filter();
-	}
-
-	if ( wp_lazy_loading_enabled( 'img', $context ) ) {
-		$tags[] = 'img';
-	}
-
-	// Experimental. Will be removed when merging unless the HTML specs are updated by that time.
-	if ( wp_lazy_loading_enabled( 'iframe', $context ) ) {
-		$tags[] = 'iframe';
-	}
-
-	if ( empty( $tags ) ) {
+	if ( ! wp_lazy_loading_enabled( 'img', $context ) ) {
 		return $content;
 	}
 
 	return preg_replace_callback(
-		'/<(' . implode( '|', $tags ) . ')(\s)[^>]+>/',
+		'/<img(\s)[^>]+>/',
 		function( array $matches ) {
 			if ( ! preg_match( '/\sloading\s*=/', $matches[0] ) ) {
-				$tag   = $matches[1];
-				$space = $matches[2];
+				$space = $matches[1];
 
-				return str_replace( '<' . $tag . $space, '<' . $tag . $space . 'loading="lazy" ', $matches[0] );
+				return str_replace( '<img' . $space, '<img' . $space . 'loading="lazy" ', $matches[0] );
 			}
 
 			return $matches[0];


### PR DESCRIPTION
This PR removes support for `iframe` tags, since they are not part of the currently proposed spec for the `loading` attribute (see #3 and #5).