### PR TITLE
Add GitHub Actions for deploys to WordPress.org

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Directories
+/.github export-ignore
+/tests export-ignore
+
+# Files
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/LICENSE export-ignore
+/README.md export-ignore
+/composer.json export-ignore
+/phpunit.xml.dist export-ignore
+
+/deploy.sh export-ignore
+/developers.md export-ignore
+/package.json export-ignore

--- a/.github/workflows/deploy-to-wordpress-dotorg.yml
+++ b/.github/workflows/deploy-to-wordpress-dotorg.yml
@@ -1,0 +1,16 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@master
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/plugin-asset-readme-update.yml
+++ b/.github/workflows/plugin-asset-readme-update.yml
@@ -1,0 +1,16 @@
+name: Plugin asset/readme update
+on:
+  push:
+    branches:
+    - master
+jobs:
+  master:
+    name: Push to master
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@master
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
### Description of the Change
- Deploys newly tagged releases on GitHub to WordPress.ORG SVN
- Deploys single commits to `master` that only affecting readme and asset files on GitHub to WordPress.ORG SVN

### Benefits
- Automates deploys to WordPress.ORG SVN and eliminates future human error

### Possible Drawbacks
- Requires GitHub Actions to be available and free to @WordPress org account
- Requires an `SVN_USERNAME` and `SVN_PASSWORD` secret be set within the Settings of this `wp-lazy-loading` GitHub repo
- Requires the above mentioned SVN username and password be a valid WordPress.ORG SVN account with access to the `wp-lazy`loading` WordPress.ORG SVN repo

### Applicable Issues
Relates to #1  