### PR TITLE
Use single regex for loading/srcset/sizes, and only modify attachment images

### DIFF
--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -52,7 +52,7 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
-		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
-		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
 	}
 
@@ -91,7 +91,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
-		$this->assertSame( $content, wp_filter_content_images( $content ) );
+		$this->assertSame( $content, wp_filter_content_tags( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
 	}
 }

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -52,7 +52,7 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
-		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
-		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
 	}
 
@@ -91,7 +91,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
-		$this->assertSame( $content, wp_filter_content_attachment_images( $content ) );
+		$this->assertSame( $content, wp_filter_content_images( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
 	}
 }

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -52,7 +52,7 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
-		$this->assertSame( $content_filtered, wp_add_lazy_load_attributes( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
-		$this->assertSame( $content_filtered, wp_add_lazy_load_attributes( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
 	}
 
@@ -91,7 +91,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
-		$this->assertSame( $content, wp_add_lazy_load_attributes( $content ) );
+		$this->assertSame( $content, wp_filter_content_attachment_images( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
 	}
 }

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -168,18 +168,21 @@ function wp_filter_content_attachment_images( $content, $context = null ) {
 		_prime_post_caches( array_keys( $attachment_ids ), false, true );
 	}
 
+	$add_srcset_sizes = 'the_content' === $context;
+	$add_loading      = wp_lazy_loading_enabled( 'img', $context );
+
 	foreach ( $selected_images as $image => $attachment_id ) {
 		$image_meta = wp_get_attachment_metadata( $attachment_id );
 
 		$filtered_image = $image;
 
 		// Add 'srcset' and 'sizes' attributes if applicable.
-		if ( 'the_content' === $context && false === strpos( $filtered_image, ' srcset=' ) ) {
+		if ( $add_srcset_sizes && false === strpos( $filtered_image, ' srcset=' ) ) {
 			$filtered_image = wp_image_add_srcset_and_sizes( $filtered_image, $image_meta, $attachment_id );
 		}
 
 		// Add 'loading' attribute if applicable.
-		if ( wp_lazy_loading_enabled( 'img', $context ) && false === strpos( $filtered_image, ' loading=' ) ) {
+		if ( $add_loading && false === strpos( $filtered_image, ' loading=' ) ) {
 			$filtered_image = wp_image_add_loading( $filtered_image, $image_meta, $attachment_id, $content, $context );
 		}
 

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -217,7 +217,7 @@ function wp_image_add_loading( $image, $image_meta, $attachment_id, $content, $c
 	 * @param string     $content       The HTML containing the image tag.
 	 * @param string     $context       Additional context, typically the current filter.
 	 */
-	$value = apply_filters( 'wp_set_image_loading', 'lazy', $image, $content, $context );
+	$value = apply_filters( 'wp_set_image_loading', 'lazy', $image, $image_meta, $attachment_id, $content, $context );
 
 	if ( $value ) {
 		if ( ! in_array( $value, array( 'lazy', 'eager' ), true ) ) {

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function _wp_lazy_loading_initialize_filters() {
 	// The following filters would be merged into core.
 	foreach ( array( 'the_content', 'the_excerpt', 'comment_text', 'widget_text_content' ) as $filter ) {
-		add_filter( $filter, 'wp_filter_content_images' );
+		add_filter( $filter, 'wp_filter_content_tags' );
 	}
 
 	// The following filters are only needed while this is a feature plugin.
@@ -120,7 +120,12 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
 }
 
 /**
- * Filters 'img' tags in post content and modifies their markup.
+ * Filters specific tags in post content and modifies their markup.
+ *
+ * This function performs the following replacements:
+ *
+ * * add 'srcset' and 'sizes' attributes to 'img' tags
+ * * add 'loading' attributes to 'img' tags
  *
  * @since (TBD)
  *
@@ -131,7 +136,7 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
  * @param string $context Optional. Additional context to pass to the filters. Defaults to `current_filter()` when not set.
  * @return string Converted content with images modified.
  */
-function wp_filter_content_images( $content, $context = null ) {
+function wp_filter_content_tags( $content, $context = null ) {
 	if ( null === $context ) {
 		$context = current_filter();
 	}

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -183,7 +183,7 @@ function wp_filter_content_attachment_images( $content, $context = null ) {
 			$filtered_image = wp_image_add_loading( $filtered_image, $image_meta, $attachment_id, $content, $context );
 		}
 
-		return str_replace( $image, $filtered_image, $content );
+		$content = str_replace( $image, $filtered_image, $content );
 	}
 
 	return $content;

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function _wp_lazy_loading_initialize_filters() {
 	// The following filters would be merged into core.
 	foreach ( array( 'the_content', 'the_excerpt', 'comment_text', 'widget_text_content' ) as $filter ) {
-		add_filter( $filter, 'wp_filter_content_attachment_images' );
+		add_filter( $filter, 'wp_filter_content_images' );
 	}
 
 	// The following filters are only needed while this is a feature plugin.
@@ -120,7 +120,7 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
 }
 
 /**
- * Filters 'img' elements in post content and modifies their markup.
+ * Filters 'img' tags in post content and modifies their markup.
  *
  * @since (TBD)
  *
@@ -131,7 +131,7 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
  * @param string $context Optional. Additional context to pass to the filters. Defaults to `current_filter()` when not set.
  * @return string Converted content with images modified.
  */
-function wp_filter_content_attachment_images( $content, $context = null ) {
+function wp_filter_content_images( $content, $context = null ) {
 	if ( null === $context ) {
 		$context = current_filter();
 	}
@@ -176,8 +176,7 @@ function wp_filter_content_attachment_images( $content, $context = null ) {
 	}
 
 	foreach ( $selected_images as $image => $attachment_id ) {
-		$image_meta = wp_get_attachment_metadata( $attachment_id );
-
+		$image_meta     = wp_get_attachment_metadata( $attachment_id );
 		$filtered_image = $image;
 
 		// Add 'srcset' and 'sizes' attributes if applicable.


### PR DESCRIPTION
This PR addresses #2, and various other related concerns:

* It introduces a new function `wp_filter_content_attachment_images()` which essentially is a copy of core's `wp_make_content_images_responsive()`, modulo the addition of an optional `$context` parameter and the second `foreach` loop (for each attachment image). This is the key change in this PR, which addresses #2.
    * The call to the core function `wp_image_add_srcset_and_sizes()` remains in `wp_filter_content_attachment_images()`. It is now only called if the `$context` (the current filter) is `the_content`, because that is the only filter this logic currently applies to, and it shouldn't be modified here because it's unrelated (even though maybe worth considering in the future). The check for an existing `srcset` attribute was moved here because it shouldn't determine the `img` tags to generally iterate through.
    * `wp_filter_content_attachment_images()` is hooked into the regular content filters like the previous `wp_add_lazy_load_attributes()` was.
    * `wp_make_content_images_responsive()` is unhooked from `the_content`. Once this is merged to core, the hook should be removed, and the function could be deprecated.
* A valid concern pointed out by @westonruter in [a comment on the announcement post](https://make.wordpress.org/core/2020/01/29/lazy-loading-images-in-wordpress-core/#comment-37865) is that replacing random images that are not WP attachments may unexpectedly add `loading` attributes to images that shouldn't be modified, such as tracking pixels. Since WordPress core's existing logic already gets the attachment IDs and even image meta anyway, there's no performance concern here.
* A new function `wp_image_add_loading()` now takes care of modifying a single image tag. Its name, signature and behavior is inspired by the existing `wp_image_add_srcset_and_sizes()`. It now also receives the `$image_meta` and `$attachment_id` already fetched by core anyway. There are now also passed to the `wp_set_image_loading` filter.
* In order to maintain the current behavior, the filter priority was set to the default of 10, from the previous 25. This is still after `do_blocks()` (which runs on 9) so should cover enough, while at the same time ensuring there's no unexpected breakage with `srcset` / `sizes`. Related: #12 