### PR TITLE
Enhancement: reuse the current content regex

### DIFF
--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -53,11 +53,11 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
 		// Do not add srcset and sizes while testing.
-		add_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
 
 		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
 
-		remove_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+		remove_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
 	}
 
 	/**
@@ -76,14 +76,14 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_filtered   = sprintf( $content, $lazy_img );
 
 		// Do not add srcset and sizes while testing.
-		add_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
 
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
 		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
-		remove_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+		remove_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
 	}
 
 	/**
@@ -98,13 +98,13 @@ class Tests_Media extends WP_UnitTestCase {
 		$content = sprintf( $content, $img );
 
 		// Do not add srcset and sizes while testing.
-		add_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
 
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
 		$this->assertSame( $content, wp_filter_content_tags( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
-		remove_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+		remove_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
 	}
 }

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -52,7 +52,7 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
-		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
-		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
 	}
 
@@ -91,7 +91,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
-		$this->assertSame( $content, wp_filter_content_images( $content ) );
+		$this->assertSame( $content, wp_filter_content_tags( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
 	}
 }

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -52,7 +52,7 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
-		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
-		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_images( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
 	}
 
@@ -91,7 +91,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
-		$this->assertSame( $content, wp_filter_content_attachment_images( $content ) );
+		$this->assertSame( $content, wp_filter_content_images( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
 	}
 }

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -52,7 +52,7 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
-		$this->assertSame( $content_filtered, wp_add_lazy_load_attributes( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
-		$this->assertSame( $content_filtered, wp_add_lazy_load_attributes( $content_unfiltered ) );
+		$this->assertSame( $content_filtered, wp_filter_content_attachment_images( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
 	}
 
@@ -91,7 +91,7 @@ class Tests_Media extends WP_UnitTestCase {
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
-		$this->assertSame( $content, wp_add_lazy_load_attributes( $content ) );
+		$this->assertSame( $content, wp_filter_content_attachment_images( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
 	}
 }

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -52,7 +52,12 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img, $img_xhtml, $img_html5, $iframe, $img_eager );
 		$content_filtered   = sprintf( $content, $lazy_img, $lazy_img_xhtml, $lazy_img_html5, $iframe, $img_eager );
 
+		// Do not add srcset and sizes while testing.
+		add_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+
 		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
+
+		remove_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
 	}
 
 	/**
@@ -70,11 +75,15 @@ class Tests_Media extends WP_UnitTestCase {
 		$content_unfiltered = sprintf( $content, $img );
 		$content_filtered   = sprintf( $content, $lazy_img );
 
+		// Do not add srcset and sizes while testing.
+		add_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+
 		// Enable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_true' );
 
 		$this->assertSame( $content_filtered, wp_filter_content_tags( $content_unfiltered ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_true' );
+		remove_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
 	}
 
 	/**
@@ -88,10 +97,14 @@ class Tests_Media extends WP_UnitTestCase {
 			%1$s';
 		$content = sprintf( $content, $img );
 
+		// Do not add srcset and sizes while testing.
+		add_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
+
 		// Disable globally for all tags.
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
 
 		$this->assertSame( $content, wp_filter_content_tags( $content ) );
 		remove_filter( 'wp_lazy_loading_enabled', '__return_false' );
+		remove_filter( 'wp_image_tag_add_srcset_and_sizes_attr', '__return_false' );
 	}
 }

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -168,18 +168,21 @@ function wp_filter_content_attachment_images( $content, $context = null ) {
 		_prime_post_caches( array_keys( $attachment_ids ), false, true );
 	}
 
+	$add_srcset_sizes = 'the_content' === $context;
+	$add_loading      = wp_lazy_loading_enabled( 'img', $context );
+
 	foreach ( $selected_images as $image => $attachment_id ) {
 		$image_meta = wp_get_attachment_metadata( $attachment_id );
 
 		$filtered_image = $image;
 
 		// Add 'srcset' and 'sizes' attributes if applicable.
-		if ( 'the_content' === $context && false === strpos( $filtered_image, ' srcset=' ) ) {
+		if ( $add_srcset_sizes && false === strpos( $filtered_image, ' srcset=' ) ) {
 			$filtered_image = wp_image_add_srcset_and_sizes( $filtered_image, $image_meta, $attachment_id );
 		}
 
 		// Add 'loading' attribute if applicable.
-		if ( wp_lazy_loading_enabled( 'img', $context ) && false === strpos( $filtered_image, ' loading=' ) ) {
+		if ( $add_loading && false === strpos( $filtered_image, ' loading=' ) ) {
 			$filtered_image = wp_image_add_loading( $filtered_image, $image_meta, $attachment_id, $content, $context );
 		}
 

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -217,7 +217,7 @@ function wp_image_add_loading( $image, $image_meta, $attachment_id, $content, $c
 	 * @param string     $content       The HTML containing the image tag.
 	 * @param string     $context       Additional context, typically the current filter.
 	 */
-	$value = apply_filters( 'wp_set_image_loading', 'lazy', $image, $content, $context );
+	$value = apply_filters( 'wp_set_image_loading', 'lazy', $image, $image_meta, $attachment_id, $content, $context );
 
 	if ( $value ) {
 		if ( ! in_array( $value, array( 'lazy', 'eager' ), true ) ) {

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function _wp_lazy_loading_initialize_filters() {
 	// The following filters would be merged into core.
 	foreach ( array( 'the_content', 'the_excerpt', 'comment_text', 'widget_text_content' ) as $filter ) {
-		add_filter( $filter, 'wp_filter_content_images' );
+		add_filter( $filter, 'wp_filter_content_tags' );
 	}
 
 	// The following filters are only needed while this is a feature plugin.
@@ -120,7 +120,12 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
 }
 
 /**
- * Filters 'img' tags in post content and modifies their markup.
+ * Filters specific tags in post content and modifies their markup.
+ *
+ * This function performs the following replacements:
+ *
+ * * add 'srcset' and 'sizes' attributes to 'img' tags
+ * * add 'loading' attributes to 'img' tags
  *
  * @since (TBD)
  *
@@ -131,7 +136,7 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
  * @param string $context Optional. Additional context to pass to the filters. Defaults to `current_filter()` when not set.
  * @return string Converted content with images modified.
  */
-function wp_filter_content_images( $content, $context = null ) {
+function wp_filter_content_tags( $content, $context = null ) {
 	if ( null === $context ) {
 		$context = current_filter();
 	}

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -183,7 +183,7 @@ function wp_filter_content_attachment_images( $content, $context = null ) {
 			$filtered_image = wp_image_add_loading( $filtered_image, $image_meta, $attachment_id, $content, $context );
 		}
 
-		return str_replace( $image, $filtered_image, $content );
+		$content = str_replace( $image, $filtered_image, $content );
 	}
 
 	return $content;

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function _wp_lazy_loading_initialize_filters() {
 	// The following filters would be merged into core.
 	foreach ( array( 'the_content', 'the_excerpt', 'comment_text', 'widget_text_content' ) as $filter ) {
-		add_filter( $filter, 'wp_filter_content_attachment_images' );
+		add_filter( $filter, 'wp_filter_content_images' );
 	}
 
 	// The following filters are only needed while this is a feature plugin.
@@ -120,7 +120,7 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
 }
 
 /**
- * Filters 'img' elements in post content and modifies their markup.
+ * Filters 'img' tags in post content and modifies their markup.
  *
  * @since (TBD)
  *
@@ -131,7 +131,7 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
  * @param string $context Optional. Additional context to pass to the filters. Defaults to `current_filter()` when not set.
  * @return string Converted content with images modified.
  */
-function wp_filter_content_attachment_images( $content, $context = null ) {
+function wp_filter_content_images( $content, $context = null ) {
 	if ( null === $context ) {
 		$context = current_filter();
 	}
@@ -176,8 +176,7 @@ function wp_filter_content_attachment_images( $content, $context = null ) {
 	}
 
 	foreach ( $selected_images as $image => $attachment_id ) {
-		$image_meta = wp_get_attachment_metadata( $attachment_id );
-
+		$image_meta     = wp_get_attachment_metadata( $attachment_id );
 		$filtered_image = $image;
 
 		// Add 'srcset' and 'sizes' attributes if applicable.

--- a/wp-lazy-loading.php
+++ b/wp-lazy-loading.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function _wp_lazy_loading_initialize_filters() {
 	// The following filters would be merged into core.
-	foreach ( array( 'the_content', 'the_excerpt', 'comment_text', 'widget_text_content' ) as $filter ) {
+	foreach ( array( 'the_content', 'the_excerpt', 'widget_text_content' ) as $filter ) {
 		add_filter( $filter, 'wp_filter_content_tags' );
 	}
 
@@ -104,7 +104,7 @@ function _wp_lazy_loading_add_attribute_to_attachment_image( $attr ) {
  */
 function wp_lazy_loading_enabled( $tag_name, $context ) {
 	// By default add to all 'img' tags.
-	// See https://github.com/whatwg/html/issues/2806
+	// See https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-loading
 	$default = ( 'img' === $tag_name );
 
 	/**
@@ -126,8 +126,8 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
  *
  * @since (TBD)
  *
- * @see wp_image_tag_add_loading_attr()
- * @see wp_image_tag_add_srcset_and_sizes_attr()
+ * @see wp_img_tag_add_loading_attr()
+ * @see wp_img_tag_add_srcset_and_sizes_attr()
  *
  * @param string $content The HTML content to be filtered.
  * @param string $context Optional. Additional context to pass to the filters. Defaults to `current_filter()` when not set.
@@ -150,9 +150,6 @@ function wp_filter_content_tags( $content, $context = null ) {
 
 	// List of the unique `img` tags found in $content.
 	$images = array();
-
-	// List of the rest of the images, either local but without attachment_id, or remote.
-	$other_images = array();
 
 	foreach ( $matches[0] as $image ) {
 		if ( preg_match( '/wp-image-([0-9]+)/i', $image, $class_id ) ) {
@@ -187,12 +184,12 @@ function wp_filter_content_tags( $content, $context = null ) {
 
 		// Add 'srcset' and 'sizes' attributes if applicable.
 		if ( $attachment_id > 0 && false === strpos( $filtered_image, ' srcset=' ) ) {
-			$filtered_image = wp_image_tag_add_srcset_and_sizes_attr( $filtered_image, $context, $attachment_id );
+			$filtered_image = wp_img_tag_add_srcset_and_sizes_attr( $filtered_image, $context, $attachment_id );
 		}
 
 		// Add 'loading' attribute if applicable.
 		if ( $add_loading_attr && false === strpos( $filtered_image, ' loading=' ) ) {
-			$filtered_image = wp_image_tag_add_loading_attr( $filtered_image, $context );
+			$filtered_image = wp_img_tag_add_loading_attr( $filtered_image, $context );
 		}
 
 		if ( $filtered_image !== $image ) {
@@ -212,7 +209,7 @@ function wp_filter_content_tags( $content, $context = null ) {
  * @param string $context Additional context to pass to the filters.
  * @return string Converted `img` tag with `loading` attribute added.
  */
-function wp_image_tag_add_loading_attr( $image, $context ) {
+function wp_img_tag_add_loading_attr( $image, $context ) {
 	/**
 	 * Filters the `loading` attribute value. Default `lazy`.
 	 *
@@ -225,7 +222,7 @@ function wp_image_tag_add_loading_attr( $image, $context ) {
 	 * @param string $image   The HTML 'img' element to be filtered.
 	 * @param string $context Additional context about how the function was called or where the img tag is.
 	 */
-	$value = apply_filters( 'wp_image_tag_add_loading_attr', 'lazy', $image, $context );
+	$value = apply_filters( 'wp_img_tag_add_loading_attr', 'lazy', $image, $context );
 
 	if ( $value ) {
 		if ( ! in_array( $value, array( 'lazy', 'eager' ), true ) ) {
@@ -248,7 +245,7 @@ function wp_image_tag_add_loading_attr( $image, $context ) {
  * @param int    $attachment_id Image attachment ID.
  * @return string Converted 'img' element with 'loading' attribute added.
  */
-function wp_image_tag_add_srcset_and_sizes_attr( $image, $context, $attachment_id ) {
+function wp_img_tag_add_srcset_and_sizes_attr( $image, $context, $attachment_id ) {
 	/**
 	 * Filters whether to add the `srcset` and `sizes` HTML attributes to the img tag. Default `true`.
 	 *
@@ -261,7 +258,7 @@ function wp_image_tag_add_srcset_and_sizes_attr( $image, $context, $attachment_i
 	 * @param string $context       Additional context about how the function was called or where the img tag is.
 	 * @param int    $attachment_id The image attachment ID.
 	 */
-	$add = apply_filters( 'wp_image_tag_add_srcset_and_sizes_attr', true, $image, $context, $attachment_id );
+	$add = apply_filters( 'wp_img_tag_add_srcset_and_sizes_attr', true, $image, $context, $attachment_id );
 
 	if ( true === $add ) {
 		$image_meta = wp_get_attachment_metadata( $attachment_id );


### PR DESCRIPTION
Based on https://github.com/WordPress/wp-lazy-loading/pull/20. This is another "patch" for https://github.com/WordPress/wp-lazy-loading/issues/2 with some changes and enhancements.

Additions/changes compared to pull/20:
- Add `loading` attribute to all img tags in the content, not just tags that have `wp-image-####` class names.
- Tweak/fix functions and vars names to make them more self-documenting.
- Introduce `wp_image_tag_add_srcset_and_sizes_attr()` to go with `wp_image_tag_add_loading_attr()`. It makes it possible to bypass adding of srcset and sizes attributes on a per-image basis, before doing anything else. This also prepares it for adding filtering of `iframe` in the future (`wp_iframe_tag_add_loading_attr()`, etc.).
- Removes the limitation from `wp_filter_content_tags()` to only add srcset and sizes when `$context` is set to `the_content` (i.e. only when run as callback to `the_content` filter). This makes the function useful for filtering any HTML string and adding all supported img tag attributes.

