### PR TITLE
Fix phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,11 +12,10 @@
 	stopOnFailure="false"
 	stopOnIncomplete="false"
 	stopOnSkipped="false"
-	syntaxCheck="false"
 	verbose="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="unit">
 			<directory suffix=".php">./tests/phpunit/tests/</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
Running PHPUnit 7.5.20 (latest that's supported by WordPress), seeing couple of warnings:
```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 17:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Line 19:
  - Element 'testsuite': The attribute 'name' is required but missing.

  Test results may not be as expected.
```
